### PR TITLE
msm8974: bring back USECASE_AUDIO_RECORD_FM_VIRTUAL

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -179,6 +179,10 @@ ifeq ($(strip $(AUDIO_FEATURE_ENABLED_KPI_OPTIMIZE)),true)
     LOCAL_CFLAGS += -DKPI_OPTIMIZE_ENABLED
 endif
 
+ifeq ($(strip $(AUDIO_FEATURE_DISABLED_FM_VIRTUAL_RECORD)),true)
+    LOCAL_CFLAGS += -DNO_FM_VIRTUAL_RECORD
+endif
+
 LOCAL_SHARED_LIBRARIES := \
 	liblog \
 	libcutils \

--- a/hal/msm8974/platform.c
+++ b/hal/msm8974/platform.c
@@ -2266,6 +2266,10 @@ int platform_update_usecase_from_source(int source, int usecase)
     ALOGV("%s: input source :%d", __func__, source);
 
     switch(source) {
+#ifndef NO_FM_VIRTUAL_RECORD
+        case AUDIO_SOURCE_FM_TUNER:
+            return USECASE_AUDIO_RECORD_FM_VIRTUAL;
+#endif
         case AUDIO_SOURCE_VOICE_UPLINK:
             return USECASE_INCALL_REC_UPLINK;
         case AUDIO_SOURCE_VOICE_DOWNLINK:


### PR DESCRIPTION
Needed to record with mic while FM is being played.
This partially reverts e450f5403adda6d23462df62a8fa5680487fc78c

Change-Id: Iaecb2bab4acbadd571effd37afe3d0116973f822